### PR TITLE
Add PgLsn::INVALID; Add PgTimestamp for standby_status_update

### DIFF
--- a/postgres-types/src/pg_lsn.rs
+++ b/postgres-types/src/pg_lsn.rs
@@ -13,6 +13,12 @@ use crate::{FromSql, IsNull, ToSql, Type};
 #[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub struct PgLsn(u64);
 
+impl PgLsn {
+    /// An un-specified or unknown LSN
+    // The C equivalent is InvalidXLogRecPtr
+    pub const INVALID: PgLsn = PgLsn(0);
+}
+
 /// Error parsing LSN.
 #[derive(Debug)]
 pub struct ParseLsnError(());

--- a/tokio-postgres/tests/test/replication.rs
+++ b/tokio-postgres/tests/test/replication.rs
@@ -1,11 +1,10 @@
 use futures::StreamExt;
-use std::time::{Duration, UNIX_EPOCH};
 
 use postgres_protocol::message::backend::LogicalReplicationMessage::{Begin, Commit, Insert};
 use postgres_protocol::message::backend::ReplicationMessage::*;
 use postgres_protocol::message::backend::TupleData;
 use postgres_types::PgLsn;
-use tokio_postgres::replication::LogicalReplicationStream;
+use tokio_postgres::replication::{LogicalReplicationStream, PgTimestamp};
 use tokio_postgres::NoTls;
 use tokio_postgres::SimpleQueryMessage::Row;
 
@@ -130,10 +129,8 @@ async fn test_replication() {
 
     // Send a standby status update and require a keep alive response
     let lsn: PgLsn = lsn.parse().unwrap();
+    let ts = PgTimestamp::now().unwrap();
 
-    // Postgres epoch is 2000-01-01T00:00:00Z
-    let pg_epoch = UNIX_EPOCH + Duration::from_secs(946_684_800);
-    let ts = pg_epoch.elapsed().unwrap().as_micros() as i64;
     stream
         .as_mut()
         .standby_status_update(lsn, lsn, lsn, ts, 1)


### PR DESCRIPTION
PgLsn:
- The postgres C code has `InvalidXLogRecPtr`, and I find this easier to understand than `PgLsn(0)`.

PgTimestamp:
- This is a work in progress! I can re-send after the two problems below are resolved.
- Ensure that timestamps are always calculated the right way; the caller doesn't need to know the epoch details.
- *PROBLEM*: This probably belongs somewhere in postgres-types? Unless this kind of timestamp is specific to replication?
- *PROBLEM*: There's already a `postgres_types::Timestamp`, so there's some risk of confusion. Maybe if this were named `ReplicationTimestamp` instead? I'm not sure what the right name should be.